### PR TITLE
Allows for settings changes from commands

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -1,6 +1,6 @@
 
-## Commands
-![SUDOku Commands](https://github.com/furSUDO/SUDOku/blob/master/github/commands.png?raw=true)
+# Commands
+![SUDOku Commands](https://github.com/furSUDO/SUDOku/blob/master/github/commands.png?raw=true)  
 You are unable to view the commands, because they are mah secrets ;p
 
 however! This is how you can build your own:
@@ -16,3 +16,16 @@ module.exports = {
 	},
 };
 ```
+
+## execute function parameters
+The `execute()` function can take up to 4 parameters in this order:
+1. `message`: the message object
+2. `args`: a `list` containing every word in the original message excluding the prefix
+3. `prefix`: the prefix of the server where the message came from
+4. `settings`: the `object` with all the servers' settings
+
+**BEWARE**: For how JavaScript works, if you pass a primitive to a function and assign a new value to it, the value on the caller will not change. Passing an `object` and adding, removing or in general modifying that object will result in the changes being applied to the state of the original object. [Click here for more information](https://www.w3schools.com/js/js_function_parameters.asp).  
+
+## Changing the settings from a command
+To edit a server's settings from a command, as for example to change a server's specific prefix, you can edit the settings object passed in as a parameter to the execute function.  
+Remember that to make those changes **permanent** you need to save them to the `settings.json` file in the root folder.

--- a/commands/example.js
+++ b/commands/example.js
@@ -4,7 +4,14 @@ module.exports = {
     usage:'an example usage',
     args: false,
 	adminOnly: false,
-	async execute(message) {
-		message.channel.send(`This is an example`);
+	async execute(message, args, prefix, settings) {
+		let stringSettings = JSON.stringify(settings);
+		let exampleString =
+			`This is an example.\nFrom commands you can access:\n` +
+			`- Message arguments: \`${args.length > 0 ? args : " "}\`\n` +
+			`- The Current server prefix: \`${prefix}\`\n` +
+			`- The Current bot settings: \`${stringSettings}\`\n` +
+			`\nRead more in the README.md file`;
+		message.channel.send(exampleString);
 	},
 };

--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ client.on("message", async (message) => {
                 userStats.xp = userStats.xp - xpToNextLevel;
                 message.channel.send(`${displayName(message)} has reached level ${userStats.level}`);
                 //sends a gif if user reaches level 69
-                if (userStats.level = 69) message.channel.send(`https://tenor.com/view/nice-gif-10653491`)
+                if (userStats.level === 69) message.channel.send(`https://tenor.com/view/nice-gif-10653491`)
             }
 
             if (SUdebugMode) console.log(`${displayName(message)} now has ${userStats.xp}\n${xpToNextLevel} needed to lvl up\nMessage: ${message.content}`);

--- a/index.js
+++ b/index.js
@@ -88,12 +88,6 @@ client.on("message", async (message) => {
         jsonfile.writeFileSync("settings.json", settings);
     }
 
-    // Reads file again because I have no clue why it didn't work otherwise but
-    // this seems to fix the issue therefore I am going to leave it in and not
-    // attempt to fix it otherwise, but maybe if you are reading this and have
-    // big brain you can suggest a fix idk lol
-    settings = jsonfile.readFileSync("settings.json");
-
     const guildSettings = settings[message.guild.id];
     const prefix = guildSettings.prefix;
 
@@ -188,7 +182,7 @@ client.on("message", async (message) => {
 
     //This executes the command
     try {
-        command.execute(message, args, prefix);
+        command.execute(message, args, prefix, settings);
     } catch (error) {
         console.error(error);
         message.reply("there was an error trying to execute that command!");


### PR DESCRIPTION
This allows custom commands such as `prefix` to change the server's specific settings.  
The way it achieves this is passing the whole `settings` object to the execute function since being an object it will be passed by reference allowing for edit. This also means that the changes have to be manually saved by the user. Ideally it would be better if the settings object was instead a **class** allowing for an easier usability and more controls resulting in less possible errors from the developer.  

### Summary of changes
- adds 4th parameter to index.js `execute()` 
- makes a better example
- edits the `README.md` file in the commands directory
- fixes the error in the check for level 69 having `=` instead of `===`